### PR TITLE
docs: Fix a few typos

### DIFF
--- a/qqweibo/api.py
+++ b/qqweibo/api.py
@@ -456,7 +456,7 @@ class API(object):
     )
 
     """ 6.friends/del取消收听某个用户 """
-    _friends_del = bind_api(          # fix confilicts with del
+    _friends_del = bind_api(          # fix conflicts with del
         path = '/friends/del',
         method = 'POST',
         allowed_param = ['name'],

--- a/qqweibo/models.py
+++ b/qqweibo/models.py
@@ -190,7 +190,7 @@ class User(Model):
         """收听某个用户"""
         assertion(not bool(self.self), "you can't follow your self")
         if self.ismyidol:
-            return                      # already flollowed
+            return                      # already followed
         else:
             self._api.friends.add(name=self.name)
     follow = add

--- a/tests/test_pyqqweibo.py
+++ b/tests/test_pyqqweibo.py
@@ -560,7 +560,7 @@ class TweetAPITestCase(APITestCase):
                                      flag=0)
         count0 = ret0.as_dict()['79504073889068']
         assert count0 > 0
-        # in some senconds
+        # in some seconds
         assert count0 - 10 <= count <= count0
 
         ret1 = api.tweet.retweetcount(ids=79504073889068,
@@ -765,7 +765,7 @@ class FriendsAPITestCase(APITestCase):
         assert not info.ismyidol
 
         try:
-            # BUG: will cause errcode=65. reason unkown
+            # BUG: will cause errcode=65. reason unknown
             api.friends.add(name='t')
         except:
             pass


### PR DESCRIPTION
There are small typos in:
- qqweibo/api.py
- qqweibo/models.py
- tests/test_pyqqweibo.py

Fixes:
- Should read `unknown` rather than `unkown`.
- Should read `seconds` rather than `senconds`.
- Should read `followed` rather than `flollowed`.
- Should read `conflicts` rather than `confilicts`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md